### PR TITLE
Fix macOS installation with Logi Options+ 2.7

### DIFF
--- a/Logi Options Plus Mini/Logi Options+ mini/logi_options_plus_installer/Feature.swift
+++ b/Logi Options Plus Mini/Logi Options+ mini/logi_options_plus_installer/Feature.swift
@@ -9,7 +9,6 @@ enum Feature: String, CaseIterable {
     case dfu = "dfu"
     case backlight = "backlight"
     case logivoice = "logivoice"
-    case aipromptbuilder = "aipromptbuilder"
     case deviceRecommendation = "device-recommendation"
     case smartactions = "smartactions"
     case actionsRing = "actions-ring"
@@ -24,7 +23,6 @@ enum Feature: String, CaseIterable {
         case .dfu: return "DFU"
         case .backlight: return "Backlight"
         case .logivoice: return "LogiVoice"
-        case .aipromptbuilder: return "AI Prompt Builder"
         case .deviceRecommendation: return "Device Recommendation"
         case .smartactions: return "Smart Actions"
         case .actionsRing: return "Actions Ring"
@@ -41,7 +39,6 @@ enum Feature: String, CaseIterable {
         case .dfu: return String(localized: "Enables or disables device firmware updates. Default value is Yes.")
         case .backlight: return String(localized: "Enables or disables keyboard backlight on the supported keyboards. Default value is Yes.")
         case .logivoice: return String(localized: "Enables or disables LogiVoice feature. Default value is Yes.")
-        case .aipromptbuilder: return String(localized: "Enables or disables AI Prompt Builder feature. Default value is Yes.")
         case .deviceRecommendation: return String(localized: "Enables or disables device recommendation feature. Default value is Yes.")
         case .smartactions: return String(localized: "Enables or disables Smart Actions feature. Default value is Yes.")
         case .actionsRing: return String(localized: "Enables or disables Actions Ring feature. Default value is Yes.")

--- a/Logi Options Plus Mini/Logi Options+ mini/logi_options_plus_installer/InstallerController.swift
+++ b/Logi Options Plus Mini/Logi Options+ mini/logi_options_plus_installer/InstallerController.swift
@@ -35,7 +35,6 @@ class InstallerController: NSObject, ObservableObject {
         .dfu: "--dfu",
         .backlight: "--backlight",
         .logivoice: "--logivoice",
-        .aipromptbuilder: "--aipromptbuilder",
         .deviceRecommendation: "--device-recommendation",
         .smartactions: "--smartactions",
         .actionsRing: "--actions-ring"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
   - update 应用程序更新
   - dfu 设备固件更新
   - logivoice 罗技语音功能
-  - aipromptbuilder  AI Prompt Builder 功能（仅限macOS）
+  - aipromptbuilder AI Prompt Builder 功能（仅限 Windows）
   - smartactions
   - actions-ring
   - device-recommendation 设备推荐功能（仅限macOS）
@@ -102,11 +102,10 @@
   5. dfu:                   Enables or disables device firmware updates.
   6. backlight:             Enables or disables keyboard backlight on the supported keyboards.
   7. logivoice:             Enables or disables LogiVoice feature.
-  8. aipromptbuilder:       Enables or disables AI Prompt Builder feature.
-  9. device-recommendation: Enables or disables device recommendation feature.
-  10. smartactions:         Enables or disables Smart Actions feature.
-  11. actions-ring:         Enables or disables Actions Ring feature.
-  12. all
+  8. device-recommendation: Enables or disables device recommendation feature.
+  9. smartactions:          Enables or disables Smart Actions feature.
+  10. actions-ring:         Enables or disables Actions Ring feature.
+  11. all
   Press enter for none
 
   Enter your choices(e.g. 2 6, default is none): 

--- a/README_EN.md
+++ b/README_EN.md
@@ -54,7 +54,7 @@ This project customizes the Logi Options+ functionality through official install
   - update: application updates
   - dfu: device firmware updates
   - logivoice: Logitech voice 
-  - aipromptbuilder: AI Prompt Builder (macOS only)
+  - aipromptbuilder: AI Prompt Builder (Windows only)
   - smartactions
   - actions-ring
   - device-recommendation: device recommendation (macOS only)
@@ -98,11 +98,10 @@ Download the Windows installer from [GitHub Releases](https://github.com/Qetesh/
      5. dfu:                   Enables or disables device firmware updates.
      6. backlight:             Enables or disables keyboard backlight on the supported keyboards.
      7. logivoice:             Enables or disables LogiVoice feature.
-     8. aipromptbuilder:       Enables or disables AI Prompt Builder feature.
-     9. device-recommendation: Enables or disables device recommendation feature.
-     10. smartactions:         Enables or disables Smart Actions feature.
-     11. actions-ring:         Enables or disables Actions Ring feature.
-     12. all
+     8. device-recommendation: Enables or disables device recommendation feature.
+     9. smartactions:          Enables or disables Smart Actions feature.
+     10. actions-ring:         Enables or disables Actions Ring feature.
+     11. all
      Press enter for none
 
      Enter your choices(e.g. 2 6, default is none): 

--- a/logi-options-plus-mini.command
+++ b/logi-options-plus-mini.command
@@ -33,11 +33,10 @@ echo "4. update:                Enables or disables app updates."
 echo "5. dfu:                   Enables or disables device firmware updates."
 echo "6. backlight:             Enables or disables keyboard backlight on the supported keyboards."
 echo "7. logivoice:             Enables or disables LogiVoice feature."
-echo "8. aipromptbuilder:       Enables or disables AI Prompt Builder feature."
-echo "9. device-recommendation: Enables or disables device recommendation feature."
-echo "10. smartactions:         Enables or disables Smart Actions feature."
-echo "11. actions-ring:         Enables or disables Actions Ring feature."
-echo "12. all"
+echo "8. device-recommendation: Enables or disables device recommendation feature."
+echo "9. smartactions:          Enables or disables Smart Actions feature."
+echo "10. actions-ring:         Enables or disables Actions Ring feature."
+echo "11. all"
 echo "Press enter for none"
 echo ""
 
@@ -52,13 +51,12 @@ update="No"
 dfu="No"
 backlight="No"
 logivoice="No"
-aipromptbuilder="No"
 device_recommendation="No"
 smartactions="No"
 actions_ring="No"
 
-# If "all" (12) is selected, set all options to "Yes"
-if [[ "$features" == *12* ]]; then
+# If "all" (11) is selected, set all options to "Yes"
+if [[ "$features" == *11* ]]; then
   analytics="Yes"
   flow="Yes"
   sso="Yes"
@@ -66,7 +64,6 @@ if [[ "$features" == *12* ]]; then
   dfu="Yes"
   backlight="Yes"
   logivoice="Yes"
-  aipromptbuilder="Yes"
   device_recommendation="Yes"
   smartactions="Yes"
   actions_ring="Yes"
@@ -82,10 +79,9 @@ else
       5) dfu="Yes" ;;
       6) backlight="Yes" ;;
       7) logivoice="Yes" ;;
-      8) aipromptbuilder="Yes" ;;
-      9) device_recommendation="Yes" ;;
-      10) smartactions="Yes" ;;
-      11) actions_ring="Yes" ;;
+      8) device_recommendation="Yes" ;;
+      9) smartactions="Yes" ;;
+      10) actions_ring="Yes" ;;
       *) echo "Invalid option: $feature";;
     esac
   done
@@ -101,7 +97,6 @@ echo "update:                   $update"
 echo "dfu:                      $dfu"
 echo "backlight:                $backlight"
 echo "logivoice:                $logivoice"
-echo "aipromptbuilder:          $aipromptbuilder"
 echo "device-recommendation:    $device_recommendation"
 echo "smartactions:             $smartactions"
 echo "actions-ring:             $actions_ring"
@@ -157,11 +152,11 @@ mv ~/Library/"Application Support/LogiOptionsPlus_bak" ~/Library/"Application Su
 
 # Installing...
 # Change the following arguments to 'Yes' if you want to install the module.
-# disable analytics,flow,sso,update,dfu,logivoice,aipromptbuilder,device-recommendation,smartactions
+# disable analytics,flow,sso,update,dfu,logivoice,device-recommendation,smartactions
 echo "$(date) | Installing $appname..."
 
 # Construct the install command with selected options
-install_command="$install_path $quiet --analytics $analytics --flow $flow --sso $sso --update $update --dfu $dfu --backlight $backlight --logivoice $logivoice --aipromptbuilder $aipromptbuilder --device-recommendation $device_recommendation --smartactions $smartactions --actions-ring $actions_ring"
+install_command="$install_path $quiet --analytics $analytics --flow $flow --sso $sso --update $update --dfu $dfu --backlight $backlight --logivoice $logivoice --device-recommendation $device_recommendation --smartactions $smartactions --actions-ring $actions_ring"
 echo "Executing: $install_command"
 
 sudo "$install_path" \
@@ -173,7 +168,6 @@ sudo "$install_path" \
         --dfu $dfu \
         --backlight $backlight \
         --logivoice $logivoice \
-        --aipromptbuilder $aipromptbuilder \
         --device-recommendation $device_recommendation \
         --smartactions $smartactions \
         --actions-ring $actions_ring >> /dev/null 2>&1


### PR DESCRIPTION
## Summary

- remove the deprecated `--aipromptbuilder` argument from the macOS app
- remove the same argument from the macOS shell installer
- keep Windows AI Prompt Builder support unchanged and update the macOS menu documentation

Logi Options+ installer 2.7.961922 rejects `--aipromptbuilder` as an invalid argument. It still exits with status 0, so Mini continues past the installer invocation and only reports failure when the installed app cannot be found.

## Verification

- `xcodebuild` Debug build for macOS succeeds with code signing disabled
- `/bin/sh -n logi-options-plus-mini.command` succeeds
- existing test scheme does not compile because its target cannot resolve the pre-existing `ZipArchive` dependency

Fixes #47